### PR TITLE
Add module-level docstrings

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,3 +1,5 @@
+"""CLI for running the log analysis pipeline."""
+
 import json
 import logging
 from pathlib import Path

--- a/src/log_analyzer_rag/core/config.py
+++ b/src/log_analyzer_rag/core/config.py
@@ -1,3 +1,11 @@
+"""Application configuration module.
+
+此模組負責讀取及初始化專案所需的各項設定，
+包含路徑位置、模型名稱以及成本控制參數等。
+所有設定皆透過 ``pydantic-settings`` 讀取環境變數，
+並提供 ``settings`` 物件供其他模組使用。
+"""
+
 import os
 from pathlib import Path
 from typing import Optional

--- a/src/log_analyzer_rag/core/logging_config.py
+++ b/src/log_analyzer_rag/core/logging_config.py
@@ -1,3 +1,5 @@
+"""Utility for configuring project-wide logging."""
+
 import logging
 import sys
 from .config import settings

--- a/src/log_analyzer_rag/data_processing/indexer.py
+++ b/src/log_analyzer_rag/data_processing/indexer.py
@@ -1,3 +1,5 @@
+"""Utilities for scoring log lines and updating the FAISS index."""
+
 import logging
 from typing import List, Tuple
 

--- a/src/log_analyzer_rag/data_processing/scoring.py
+++ b/src/log_analyzer_rag/data_processing/scoring.py
@@ -1,3 +1,5 @@
+"""Heuristic scoring functions used during log preprocessing."""
+
 import logging
 from typing import List
 

--- a/src/log_analyzer_rag/main_process.py
+++ b/src/log_analyzer_rag/main_process.py
@@ -1,3 +1,5 @@
+"""Entry point for processing log files and orchestrating analysis."""
+
 import json
 import logging
 from datetime import datetime, timezone

--- a/src/log_analyzer_rag/rag_pipeline/cache.py
+++ b/src/log_analyzer_rag/rag_pipeline/cache.py
@@ -1,3 +1,5 @@
+"""Simple in-memory LRU cache used by the LLM pipeline."""
+
 import logging
 from collections import OrderedDict
 from typing import Any, Optional

--- a/src/log_analyzer_rag/rag_pipeline/embedding.py
+++ b/src/log_analyzer_rag/rag_pipeline/embedding.py
@@ -1,3 +1,5 @@
+"""Text embedding utilities used for vectorizing log lines."""
+
 import hashlib
 import logging
 import os

--- a/src/log_analyzer_rag/rag_pipeline/llm.py
+++ b/src/log_analyzer_rag/rag_pipeline/llm.py
@@ -1,3 +1,5 @@
+"""LLM analysis pipeline wrapped around LangChain and Gemini models."""
+
 import json
 import logging
 from datetime import datetime, timedelta, timezone

--- a/src/log_analyzer_rag/rag_pipeline/vector_store.py
+++ b/src/log_analyzer_rag/rag_pipeline/vector_store.py
@@ -1,3 +1,5 @@
+"""FAISS based vector store helper classes."""
+
 import logging
 from pathlib import Path
 from typing import List, Tuple, Optional

--- a/src/log_analyzer_rag/utils/file_tracker.py
+++ b/src/log_analyzer_rag/utils/file_tracker.py
@@ -1,3 +1,5 @@
+"""File utilities for tracking log file read positions."""
+
 import bz2
 import gzip
 import io


### PR DESCRIPTION
## Summary
- document modules with top-level docstrings
- ensure every Python file ends with a newline

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842cde1a6f0832084af996b2572fd63